### PR TITLE
Use IDomainEvent interface in IEntity

### DIFF
--- a/Entities/Appointment.cs
+++ b/Entities/Appointment.cs
@@ -12,7 +12,7 @@ namespace DomainEventsConsole.Model
         public string EmailAddress { get; private set; }
         public DateTime? ConfirmationReceivedDate { get; private set; }
 
-        public List<INotification> Events { get; set; } = new List<INotification>();
+        public List<IDomainEvent> Events { get; set; } = new List<IDomainEvent>();
         protected Appointment() : this(Guid.NewGuid())
         {
         }

--- a/Interfaces/IEntity.cs
+++ b/Interfaces/IEntity.cs
@@ -7,6 +7,6 @@ namespace DomainEventsConsole.Interfaces
     public interface IEntity
     {
         Guid Id { get; }
-        List<INotification> Events { get; }
+        List<IDomainEvent> Events { get; }
     }
 }


### PR DESCRIPTION
The code used MediatR's `INotification` interface in the `IEntity` and `Appointment`. I guess this was a mistake since there is an interface `IDomainEvent` defined. This interface is supposed to create an abstraction for the app to not have a direct dependency on MediatR in our `IEntity`.